### PR TITLE
typo fixed on line 34 of winter2021-_posts-2021-01-14-files-and-directories.md

### DIFF
--- a/_posts/2021-01-14-files-directories-markdown.md
+++ b/_posts/2021-01-14-files-directories-markdown.md
@@ -31,7 +31,7 @@ CPNT 201 is all about the tools that we use to support our (soon to be) coding a
 3. **Feb 8**: Vector Image software (i.e. Illustrator, in the before times)
 4. **Mar 2**: Build Tools (Sass, minification)
 
-Today we'll be covering the core skills we'll need to use Git and GH effectively: File management and core command line skillz.
+Today we'll be covering the core skills we'll need to use Git and GH effectively: File management and core command line skills.
 
 
 ## Pre-requisites


### PR DESCRIPTION
Small typo on line 34 of winter-2021/_posts/2021-01-14/files-and-directories.md, the word "skillz" should be spelt as "skills" grammatically speaking. 